### PR TITLE
Fixes to support networkx 2.4

### DIFF
--- a/sdfpy/core.py
+++ b/sdfpy/core.py
@@ -167,19 +167,19 @@ class SDFGraph( nx.MultiDiGraph ):
         else:
             attr_dict = attr
 
-        assert n not in self.node, "Node already present, remove first"
+        assert n not in self.nodes, "Node already present, remove first"
 
         wcet = attr_dict['wcet'] = SDFGraph.validate_vector(n, attr_dict.get('wcet', 0), 'wcet')
         super().add_node( n, attr_dict)
 
         # set period and phases
-        self.node[ n ]['period'] = self.node[ n ]['phases'] = len(wcet)
+        self.nodes[ n ]['period'] = self.nodes[ n ]['phases'] = len(wcet)
 
     def period(self, v):
-        return self.node[v].get('period')
+        return self.nodes[v].get('period')
 
     def phases( self, v ):
-        return self.node[v].get('phases')
+        return self.nodes[v].get('phases')
 
     def rates( self, v, w ):
         data = self[v][w]
@@ -206,8 +206,8 @@ class SDFGraph( nx.MultiDiGraph ):
 
         # update phases
         try:
-            phases_u = self.node[u].get('phases', 1)
-            self.node[ u ]['phases'] = lcm( len(production), phases_u )
+            phases_u = self.nodes[u].get('phases', 1)
+            self.nodes[ u ]['phases'] = lcm( len(production), phases_u )
         except KeyError:
             super().add_node( u, wcet = Cyclic( 0 ), phases = len( production ), period = 1 )
 
@@ -216,8 +216,8 @@ class SDFGraph( nx.MultiDiGraph ):
 
         # update phases
         try:
-            phases_v = self.node[v].get('phases', 1)
-            self.node[ v ]['phases'] = lcm( len(consumption), phases_v )
+            phases_v = self.nodes[v].get('phases', 1)
+            self.nodes[ v ]['phases'] = lcm( len(consumption), phases_v )
         except KeyError:
             super().add_node( v, wcet = Cyclic( 0 ), phases = len( consumption ), period = 1 )
 
@@ -237,7 +237,7 @@ class SDFGraph( nx.MultiDiGraph ):
             toks = attr.get('tokens')
 
             aux, c = "aux_0", 0
-            while aux in self.node:
+            while aux in self.nodes:
                 c += 1
                 aux = "aux_{}".format(c)
 
@@ -323,8 +323,8 @@ class SDFGraph( nx.MultiDiGraph ):
             # get rates of channel (v, w)
             data = self.get_edge_data( v, w, key )
             p_vw, c_vw = data.get('production'), data.get('consumption')
-            v_period = self.node[ v ]['period']
-            w_period = self.node[ w ]['period']
+            v_period = self.nodes[ v ]['period']
+            w_period = self.nodes[ w ]['period']
 
             # if there is an edge (w, v) in sdfg, check whether it's consistent with (v, w)
             if v != w and self.has_edge(w, v):

--- a/sdfpy/graphs.py
+++ b/sdfpy/graphs.py
@@ -270,8 +270,10 @@ def shortest_distances( g, root, weight_attr = "weight" ):
             try:
                 # visit next child
                 children = visited[ v ]
+                import pdb
+                pdb.set_trace()
                 try:
-                    _, w, key, data = next( children )
+                    _, w, key, data = next( children)
                     weight = data.get( weight_attr )
                     distance_to_w = distances.get( w )
                     distance_via_v = distance_from_v + weight

--- a/sdfpy/graphs.py
+++ b/sdfpy/graphs.py
@@ -263,6 +263,8 @@ def shortest_distances( g, root, weight_attr = "weight" ):
     while queue:
         # run DFS from nodes in queue
         visited = dict()
+        # maintain iterators for all the visited nodes
+        visited_it = dict()
         while queue:
             # peek queue
             v = queue[ -1 ]
@@ -270,10 +272,11 @@ def shortest_distances( g, root, weight_attr = "weight" ):
             try:
                 # visit next child
                 children = visited[ v ]
-                import pdb
-                pdb.set_trace()
+                if v not in visited_it:
+                    visited_it[v]= children.__iter__()
+                children_it = visited_it[v]
                 try:
-                    _, w, key, data = next( children)
+                    _, w, key, data = next( children_it)
                     weight = data.get( weight_attr )
                     distance_to_w = distances.get( w )
                     distance_via_v = distance_from_v + weight
@@ -301,13 +304,13 @@ def shortest_distances( g, root, weight_attr = "weight" ):
                 except StopIteration:
                     # post visit v
                     post_order.append( v )
-
                     # indicate that v is post-visited
                     visited[ v ] = None
                     queue.pop()
             except KeyError:
                 # not visited yet, pre-visit v
                 visited[ v ] = g.out_edges( v, keys = True, data = True )
+
 
         # go over nodes in reverse post order (i.e. topological order)
         visited = dict()

--- a/sdfpy/mcr.py
+++ b/sdfpy/mcr.py
@@ -23,9 +23,16 @@ class InfeasibleException( PositiveCycle ):
     def __init__(self, cycle):
         super().__init__( cycle )
 
+
+# Added for compatibility with newer versions of networkx
+def strongly_connected_components_sg(g):
+    for c in nx.strongly_connected_components(g):
+        yield g.subgraph(c)
+
 def max_cycle_ratio( g, estimate = None ):
     maxratio, arg_cycle = None, None
-    for scc in nx.strongly_connected_component_subgraphs( g ):
+    #for scc in nx.strongly_connected_component_subgraphs( g ):
+    for scc in strongly_connected_components_sg( g ):
         root = next( iter( scc.nodes() ))
         scc_mcr, cycle = compute_mcr_component( scc, root, estimate )
         if scc_mcr is None:
@@ -36,7 +43,8 @@ def max_cycle_ratio( g, estimate = None ):
             arg_cycle = cycle
 
     forest = Forest()
-    for scc in nx.strongly_connected_component_subgraphs( g, False ):
+    #for scc in nx.strongly_connected_component_subgraphs( g, False ):
+    for scc in strongly_connected_components_sg( g):
         if scc.number_of_edges() == 0:
             continue
 

--- a/sdfpy/mcr.py
+++ b/sdfpy/mcr.py
@@ -24,14 +24,15 @@ class InfeasibleException( PositiveCycle ):
         super().__init__( cycle )
 
 
-# Added for compatibility with newer versions of networkx
 def strongly_connected_components_sg(g):
+    '''
+    Returns strongly connected commponent subgraphs
+    '''
     for c in nx.strongly_connected_components(g):
         yield g.subgraph(c)
 
 def max_cycle_ratio( g, estimate = None ):
     maxratio, arg_cycle = None, None
-    #for scc in nx.strongly_connected_component_subgraphs( g ):
     for scc in strongly_connected_components_sg( g ):
         root = next( iter( scc.nodes() ))
         scc_mcr, cycle = compute_mcr_component( scc, root, estimate )
@@ -43,7 +44,6 @@ def max_cycle_ratio( g, estimate = None ):
             arg_cycle = cycle
 
     forest = Forest()
-    #for scc in nx.strongly_connected_component_subgraphs( g, False ):
     for scc in strongly_connected_components_sg( g):
         if scc.number_of_edges() == 0:
             continue

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -15,8 +15,8 @@ class TestLoadJSON(unittest.TestCase):
             self.assertEqual( s[('a', 'b')], 1 )
             self.assertEqual( s[('b', 'a')], 1 )
             self.assertEqual( s[('b', 'b')], 2 )
-            self.assertEqual( g.node['a']['period'], 1 )
-            self.assertEqual( g.node['b']['period'], 3 )
+            self.assertEqual( g.nodes['a']['period'], 1 )
+            self.assertEqual( g.nodes['b']['period'], 3 )
         except Exception as e:
             self.fail()
 
@@ -35,9 +35,9 @@ class TestLoadJSON(unittest.TestCase):
             self.assertEqual( s[('b', 'c')], 2 )
             self.assertEqual( s[('c', 'b')], 2 )
             self.assertEqual( s[('c', 'c')], 2 )
-            self.assertEqual( g.node['a']['period'], 1 )
-            self.assertEqual( g.node['b']['period'], 3 )
-            self.assertEqual( g.node['c']['period'], 1 )
+            self.assertEqual( g.nodes['a']['period'], 1 )
+            self.assertEqual( g.nodes['b']['period'], 3 )
+            self.assertEqual( g.nodes['c']['period'], 1 )
         except Exception as e:
             self.fail()
 
@@ -54,8 +54,8 @@ class TestLoadYAML(unittest.TestCase):
             self.assertEqual( s[('a', 'b')], 1 )
             self.assertEqual( s[('b', 'a')], 1 )
             self.assertEqual( s[('b', 'b')], 2 )
-            self.assertEqual( g.node['a']['period'], 1 )
-            self.assertEqual( g.node['b']['period'], 3 )
+            self.assertEqual( g.nodes['a']['period'], 1 )
+            self.assertEqual( g.nodes['b']['period'], 3 )
         except Exception as e:
             self.fail()
 
@@ -74,9 +74,9 @@ class TestLoadYAML(unittest.TestCase):
             self.assertEqual( s[('b', 'c')], 2 )
             self.assertEqual( s[('c', 'b')], 2 )
             self.assertEqual( s[('c', 'c')], 2 )
-            self.assertEqual( g.node['a']['period'], 1 )
-            self.assertEqual( g.node['b']['period'], 3 )
-            self.assertEqual( g.node['c']['period'], 1 )
+            self.assertEqual( g.nodes['a']['period'], 1 )
+            self.assertEqual( g.nodes['b']['period'], 3 )
+            self.assertEqual( g.nodes['c']['period'], 1 )
         except Exception as e:
             self.fail()
 

--- a/tests/test_mcr.py
+++ b/tests/test_mcr.py
@@ -3,6 +3,7 @@ import networkx as nx
 import sdfpy.mcr as mcr
 from fractions import Fraction
 
+
 def canonicalform( ls ):
     m = min( ls )
     while ls[ 0 ] > m:


### PR DESCRIPTION
This PR contains:
- fixes to support networkx 2.4+, in particular, some function is no longer available
- minimal fixes to data structure accesses

This passes all the tests contained in the `tests` folder

